### PR TITLE
Update last sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -17,6 +18,7 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        google()
     }
 }
 apply plugin: 'com.android.library'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ dependencies {
     compile 'com.google.android.gms:play-services-gcm:10.2.6'
 
     compile 'me.leolin:ShortcutBadger:1.1.22@aar'
-    compile 'com.adpdigital.push:chabok-lib:2.13.4'
+    compile 'com.adpdigital.push:chabok-lib:2.14.0'
 }

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -192,10 +192,12 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
                 response.putString("id", eventMessage.getId());
                 response.putString("eventName", eventMessage.getName());
                 response.putString("installationId", eventMessage.getInstallationId());
-                try {
-                    response.putMap("data", toWritableMap(eventMessage.getData()));
-                } catch (JSONException e) {
-                    e.printStackTrace();
+                if (eventMessage.getData() != null) {
+                    try {
+                        response.putMap("data", toWritableMap(eventMessage.getData()));
+                    } catch (JSONException e) {
+                        e.printStackTrace();
+                    }
                 }
 
                 sendEvent("onEvent", response);

--- a/history.md
+++ b/history.md
@@ -1,7 +1,8 @@
 ## History
 
 ### v1.0.4 (10/11/2018)
-- Update Chabok android SDK version to [v2.13.4](https://github.com/chabokpush/chabok-client-android/releases/tag/v2.13.4)
+- Update Chabok android SDK version to [v2.14.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v2.14.0)
+- Update Chabok iOS SDK version to [v1.18.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v1.18.0)
 - Fix promise reject for calling `getUserId` and `getInstallationId`
 
 ### v1.0.3 (10/11/2018)

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -313,13 +313,17 @@ RCT_EXPORT_METHOD(track:(NSString *) trackName data:(NSDictionary *) data) {
 
 -(void) pushClientManagerDidReceivedEventMessage:(EventMessage *)eventMessage{
     if (self.bridge) {
-        NSDictionary *event = @{
-                                @"id":eventMessage.id,
-                                @"installationId":eventMessage.deviceId,
-                                @"eventName":eventMessage.eventName,
-                                @"data":eventMessage.data
-                                };
-        [self sendEventWithName:@"onEvent" body:event];
+        NSDictionary *eventMessageDic =  @{
+                                           @"id":eventMessage.id,
+                                           @"installationId":eventMessage.deviceId,
+                                           @"eventName":eventMessage.eventName
+                                           };
+        NSMutableDictionary *eventPayload = [NSMutableDictionary.alloc initWithDictionary:eventMessageDic];
+        if (eventMessage.data) {
+            [eventPayload setObject:eventMessage.data forKey:@"data"];
+        }
+        
+        [self sendEventWithName:@"onEvent" body:[eventPayload copy]];
     }
 }
 


### PR DESCRIPTION
## History

### v1.0.4 (10/11/2018)
- Update Chabok android SDK version to [v2.14.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v2.14.0)
- Update Chabok iOS SDK version to [v1.18.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v1.18.0)
- Fix promise reject for calling `getUserId` and `getInstallationId`
