### PR TITLE
Feat/influence

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'me.leolin:ShortcutBadger:1.1.22@aar'
-    compile 'com.adpdigital.push:chabok-lib:2.16.0'
+    compile 'com.adpdigital.push:chabok-lib:2.17.0'
     compile "com.google.android.gms:play-services-gcm:10.2.6"
     compile 'com.android.installreferrer:installreferrer:1.0'
 }

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -711,6 +711,24 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
             e.printStackTrace();
         }
     }
+
+    @ReactMethod
+    public void setOnDeeplinkResponseListener(final boolean shouldLaunchDeeplink, final Promise promise) {
+        if (chabok != null) {
+            chabok.setOnDeeplinkResponseListener(new OnDeeplinkResponseListener() {
+                @Override
+                public boolean launchReceivedDeeplink(Uri uri) {
+                    if (uri != null){
+                        promise.resolve(uri);
+                    } else {
+                        return false;
+                    }
+                    return shouldLaunchDeeplink;
+                }
+            });
+        }
+    }
+
     @ReactMethod
     public void subscribeEvent(final String eventName, final Promise promise) {
         if (TextUtils.isEmpty(eventName)) {

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -883,21 +883,21 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
     }
 
     @ReactMethod
-    public void setUserInfo(ReadableMap data){
+    public void setUserAttributes(ReadableMap data){
         if (chabok != null) {
             if (data != null) {
                 HashMap<String, Object> userInfo = new HashMap<String, Object>(toMap(data));
-                chabok.setUserInfo(userInfo);
+                chabok.setUserAttributes(userInfo);
             }
         }
     }
 
     @ReactMethod
-    public void getUserInfo(final Promise promise) {
+    public void getUserAttributes(final Promise promise) {
         if (chabok != null) {
-            promise.resolve(chabok.getUserInfo());
+            promise.resolve(chabok.getUserAttributes());
         } else {
-            Throwable throwable = new Throwable("SDK not initialized");
+            Throwable throwable = new Throwable("Chabok SDK is not initialized");
             promise.reject(throwable);
         }
     }

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -18,11 +18,13 @@ import com.adpdigital.push.AdpPushClient;
 import com.adpdigital.push.AppListener;
 import com.adpdigital.push.AppState;
 import com.adpdigital.push.Callback;
+import com.adpdigital.push.ChabokEvent;
 import com.adpdigital.push.ChabokNotification;
 import com.adpdigital.push.ChabokNotificationAction;
 import com.adpdigital.push.ConnectionStatus;
 import com.adpdigital.push.EventMessage;
 import com.adpdigital.push.NotificationHandler;
+import com.adpdigital.push.OnDeeplinkResponseListener;
 import com.adpdigital.push.PushMessage;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -169,7 +171,7 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
 
                 notificationOpenedEvent(message, notificationAction);
 
-                return false;
+                return true;
             }
         });
 
@@ -209,11 +211,11 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
             response.putString("actionUrl", notificationAction.actionUrl);
         }
 
-        if (notificationAction.type == ChabokNotificationAction.a.Opened){
+        if (notificationAction.type == ChabokNotificationAction.ActionType.Opened){
             response.putString("actionType", "opened");
-        } else if (notificationAction.type == ChabokNotificationAction.a.Dismissed) {
+        } else if (notificationAction.type == ChabokNotificationAction.ActionType.Dismissed) {
             response.putString("actionType", "dismissed");
-        } else if (notificationAction.type == ChabokNotificationAction.a.ActionTaken) {
+        } else if (notificationAction.type == ChabokNotificationAction.ActionType.ActionTaken) {
             response.putString("actionType", "action_taken");
         }
 

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -719,7 +719,7 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
                 @Override
                 public boolean launchReceivedDeeplink(Uri uri) {
                     if (uri != null){
-                        promise.resolve(uri);
+                        promise.resolve(uri.toString());
                     } else {
                         return false;
                     }

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -679,6 +679,39 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
     }
 
     @ReactMethod
+    public void trackPurchase(String eventName, ReadableMap data) {
+        try {
+            JSONObject jsonData = toJsonObject(data);
+            double revenue = 0;
+            String currency = null;
+            JSONObject eventData = null;
+            if (!jsonData.has("revenue")){
+                throw new IllegalArgumentException("Invalid revenue");
+            }
+            revenue = jsonData.getDouble("revenue");
+            if (jsonData.has("currency")) {
+                currency = jsonData.getString("currency");
+            }
+
+            if (jsonData.has("data")) {
+                eventData = jsonData.getJSONObject("data");
+            }
+
+            ChabokEvent chabokEvent = new ChabokEvent(revenue);
+            if (currency != null){
+                chabokEvent.setRevenue(revenue, currency);
+            }
+
+            if (eventData != null){
+                chabokEvent.setData(eventData);
+            }
+
+            chabok.trackPurchase(eventName, chabokEvent);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+    @ReactMethod
     public void subscribeEvent(final String eventName, final Promise promise) {
         if (TextUtils.isEmpty(eventName)) {
             promise.reject(new IllegalArgumentException("eventName parameter is null or empty"));

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -921,6 +921,13 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
     }
 
     @ReactMethod
+    public void incrementUserAttribute(String attribute, int value) {
+        if (chabok != null) {
+            chabok.incrementUserAttribute(attribute, value);
+        }
+    }
+
+    @ReactMethod
     public void setDefaultTracker(final String defaultTracker){
         if (chabok != null){
             chabok.setDefaultTracker(defaultTracker);

--- a/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
+++ b/android/src/main/java/com/adpdigital/push/rn/AdpPushClientModule.java
@@ -928,6 +928,13 @@ class AdpPushClientModule extends ReactContextBaseJavaModule implements Lifecycl
     }
 
     @ReactMethod
+    public void setDefaultNotificationChannel(String channelName) {
+        if (chabok != null) {
+            chabok.setDefaultNotificationChannel(channelName);
+        }
+    }
+
+    @ReactMethod
     public void setDefaultTracker(final String defaultTracker){
         if (chabok != null){
             chabok.setDefaultTracker(defaultTracker);

--- a/history.md
+++ b/history.md
@@ -1,4 +1,15 @@
 ## History
+### v1.4.0 (26/06/2019)
+- Update Chabok iOS SDK ([v1.20.0](https://github.com/chabokpush/chabok-client-ios/releases/tag/v1.20.0))
+- Update Chabok android SDK ([v2.17.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v2.17.0))
+- Now Chabok supports user revenue with `trackPurchase` method.
+- Now Chabok supports direct/in-direct notification influence.
+- Now Chabok supports deferred deep linking with `setDeeplinkCallbackListener` method.
+- Add `getUserAttributes` and `setUserAttributes` method.
+- Add `setDefaultNotificationChannel` method for changing the default name of notification channel (Android 8 or higher).
+
+### Upgrade:
+- `getUserInfo` and `setUserInfo` is deprecated and replaced with `getUserAttributes` and `setUserAttributes`.
 
 ### v1.3.0 (11/05/2019)
 

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -20,79 +20,79 @@
 @end
 
 @implementation AdpPushClient
-    
-    @dynamic coldStartNotificationResult;
-    static NSDictionary *_coldStartNotificationResult;
-    
-    RCT_EXPORT_MODULE()
-    
+
+@dynamic coldStartNotificationResult;
+static NSDictionary *_coldStartNotificationResult;
+
+RCT_EXPORT_MODULE()
+
 #pragma mark - Initilaizer
+
+RCT_EXPORT_METHOD(init:(NSString *) appId
+                  apiKey:(NSString *) apiKey
+                  username:(NSString *) username
+                  password:(NSString *) password
+                  devMode:(BOOL) devMode
+                  promise:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     
-    RCT_EXPORT_METHOD(init:(NSString *) appId
-                      apiKey:(NSString *) apiKey
-                      username:(NSString *) username
-                      password:(NSString *) password
-                      devMode:(BOOL) devMode
-                      promise:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        
-        [PushClientManager setDevelopment:devMode];
-        NSArray *appIds = [appId componentsSeparatedByString:@"/"];
-        self.appId = appIds.firstObject;
-        
-        BOOL state = [PushClientManager.defaultManager registerApplication:self.appId
-                                                                    apiKey:apiKey
-                                                                  userName:username
-                                                                  password:password];
-        
-        if (state) {
-            RCTLogInfo(@"Initilized sucessfully");
-            resolve(@{@"result":@"Initilized sucessfully"});
-        } else {
-            RCTLogInfo(@"Could not init chabok parameters");
-            NSError *error = [[NSError alloc] initWithDomain:NSLocalizedDescriptionKey
-                                                        code:400
-                                                    userInfo:@{
-                                                               @"result":@"Could not init chabok parameters"
+    [PushClientManager setDevelopment:devMode];
+    NSArray *appIds = [appId componentsSeparatedByString:@"/"];
+    self.appId = appIds.firstObject;
+    
+    BOOL state = [PushClientManager.defaultManager registerApplication:self.appId
+                                                                apiKey:apiKey
+                                                              userName:username
+                                                              password:password];
+    
+    if (state) {
+        RCTLogInfo(@"Initilized sucessfully");
+        resolve(@{@"result":@"Initilized sucessfully"});
+    } else {
+        RCTLogInfo(@"Could not init chabok parameters");
+        NSError *error = [[NSError alloc] initWithDomain:NSLocalizedDescriptionKey
+                                                    code:400
+                                                userInfo:@{
+                                                           @"result":@"Could not init chabok parameters"
                                                            }];
         reject(@"400",@"Could not init chabok parameters",error);
     }
     [PushClientManager.defaultManager addDelegate:self];
     [PushClientManager.defaultManager application:UIApplication.sharedApplication
                     didFinishLaunchingWithOptions:nil];
-    }
+}
+
+RCT_EXPORT_METHOD(initializeApp:(NSDictionary *) options
+                  promise:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     
-    RCT_EXPORT_METHOD(initializeApp:(NSDictionary *) options
-                      promise:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
+    if(options == nil || [options isEqual:[NSNull null]]){
+        RCTLogInfo(@"Option parameter is null");
+        NSError *error = [[NSError alloc] initWithDomain:NSLocalizedDescriptionKey
+                                                    code:400
+                                                userInfo:@{
+                                                           @"result":@"Could not init chabok parameters"
+                                                           }];
+        reject(@"400",@"Could not init chabok parameters",error);
+    } else {
+        NSString *appId = [options valueForKey:@"appId"];
+        NSString *apiKey = [options valueForKey:@"apiKey"];
+        NSString *username = [options valueForKey:@"username"];
+        NSString *password = [options valueForKey:@"password"];
+        BOOL devMode = [[options valueForKey:@"devMode"] boolValue];
+        NSArray *appIds = [appId componentsSeparatedByString:@"/"];
         
-        if(options == nil || [options isEqual:[NSNull null]]){
-            RCTLogInfo(@"Option parameter is null");
-            NSError *error = [[NSError alloc] initWithDomain:NSLocalizedDescriptionKey
-                                                        code:400
-                                                    userInfo:@{
-                                                               @"result":@"Could not init chabok parameters"
-                                                               }];
-            reject(@"400",@"Could not init chabok parameters",error);
-        } else {
-            NSString *appId = [options valueForKey:@"appId"];
-            NSString *apiKey = [options valueForKey:@"apiKey"];
-            NSString *username = [options valueForKey:@"username"];
-            NSString *password = [options valueForKey:@"password"];
-            BOOL devMode = [[options valueForKey:@"devMode"] boolValue];
-            NSArray *appIds = [appId componentsSeparatedByString:@"/"];
-            
-            [self init:appIds.firstObject
-                apiKey:apiKey
-              username:username
-              password:password
-               devMode:devMode
-               promise:resolve
-              rejecter:reject];
-            
-        }
+        [self init:appIds.firstObject
+            apiKey:apiKey
+          username:username
+          password:password
+           devMode:devMode
+           promise:resolve
+          rejecter:reject];
+        
     }
-    
+}
+
 +(void) registerToUNUserNotificationCenter{
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     center.delegate = PushClientManager.defaultManager;
@@ -100,238 +100,238 @@
         if (!error) {
         }}];
 }
-    
+
 #pragma mark - Register methods
-    
-    RCT_EXPORT_METHOD(registerAsGuest) {
-        BOOL state = [PushClientManager.defaultManager registerAsGuest];
+
+RCT_EXPORT_METHOD(registerAsGuest) {
+    BOOL state = [PushClientManager.defaultManager registerAsGuest];
+    if (state) {
+        RCTLogInfo(@"Registered to chabok");
+    } else {
+        RCTLogInfo(@"Fail to registered to chabok");
+    }
+}
+
+RCT_EXPORT_METHOD(register:(NSString *)userId) {
+    if (userId && ![userId isEqual:[NSNull null]]){
+        BOOL state = [PushClientManager.defaultManager registerUser:userId];
         if (state) {
             RCTLogInfo(@"Registered to chabok");
         } else {
             RCTLogInfo(@"Fail to registered to chabok");
         }
+    } else {
+        RCTLogInfo(@"Could not register userId to chabok");
     }
-    
-    RCT_EXPORT_METHOD(register:(NSString *)userId) {
-        if (userId && ![userId isEqual:[NSNull null]]){
-            BOOL state = [PushClientManager.defaultManager registerUser:userId];
-            if (state) {
-                RCTLogInfo(@"Registered to chabok");
-            } else {
-                RCTLogInfo(@"Fail to registered to chabok");
-            }
+}
+
+RCT_EXPORT_METHOD(register:(NSString *)userId channel:(NSString *) channel) {
+    if (userId && ![userId isEqual:[NSNull null]]){
+        
+        BOOL state = [PushClientManager.defaultManager registerUser:userId
+                                                           channels:@[channel]];
+        if (state) {
+            RCTLogInfo(@"Registered to chabok with channel");
         } else {
-            RCTLogInfo(@"Could not register userId to chabok");
+            RCTLogInfo(@"Fail to registered to chabok");
         }
+    } else {
+        RCTLogInfo(@"Could not register userId to chabok with channel");
     }
-    
-    RCT_EXPORT_METHOD(register:(NSString *)userId channel:(NSString *) channel) {
-        if (userId && ![userId isEqual:[NSNull null]]){
-            
-            BOOL state = [PushClientManager.defaultManager registerUser:userId
-                                                               channels:@[channel]];
-            if (state) {
-                RCTLogInfo(@"Registered to chabok with channel");
-            } else {
-                RCTLogInfo(@"Fail to registered to chabok");
-            }
+}
+
+RCT_EXPORT_METHOD(register:(NSString *)userId channels:(NSArray *) channels) {
+    if (userId && ![userId isEqual:[NSNull null]]){
+        
+        NSArray *chnl = @[];
+        if (![channels isEqual:[NSNull null]] && channels) {
+            chnl = channels;
+        }
+        BOOL state = [PushClientManager.defaultManager registerUser:userId
+                                                           channels:chnl registrationHandler:^(BOOL isRegistered, NSString *userId, NSError *error) {
+                                                               RCTLogInfo(@"isRegistered : %d userId : %@ error : %@",isRegistered, userId, error );
+                                                               if (error) {
+                                                                   [self sendEventWithName:@"onRegister" body:@{@"error":error,
+                                                                                                                @"isRegister":@(NO)
+                                                                                                                }];
+                                                               } else {
+                                                                   [self sendEventWithName:@"onRegister" body:@{@"isRegister":@(isRegistered)}];
+                                                               }
+                                                           }];
+        if (state) {
+            RCTLogInfo(@"Registered to chabok with channels");
         } else {
-            RCTLogInfo(@"Could not register userId to chabok with channel");
+            RCTLogInfo(@"Fail to registered to chabok");
         }
+    } else {
+        RCTLogInfo(@"Could not register userId to chabok with channels");
     }
-    
-    RCT_EXPORT_METHOD(register:(NSString *)userId channels:(NSArray *) channels) {
-        if (userId && ![userId isEqual:[NSNull null]]){
-            
-            NSArray *chnl = @[];
-            if (![channels isEqual:[NSNull null]] && channels) {
-                chnl = channels;
-            }
-            BOOL state = [PushClientManager.defaultManager registerUser:userId
-                                                               channels:chnl registrationHandler:^(BOOL isRegistered, NSString *userId, NSError *error) {
-                                                                   RCTLogInfo(@"isRegistered : %d userId : %@ error : %@",isRegistered, userId, error );
-                                                                   if (error) {
-                                                                       [self sendEventWithName:@"onRegister" body:@{@"error":error,
-                                                                                                                    @"isRegister":@(NO)
-                                                                                                                    }];
-                                                                   } else {
-                                                                       [self sendEventWithName:@"onRegister" body:@{@"isRegister":@(isRegistered)}];
-                                                                   }
-                                                               }];
-            if (state) {
-                RCTLogInfo(@"Registered to chabok with channels");
-            } else {
-                RCTLogInfo(@"Fail to registered to chabok");
-            }
-        } else {
-            RCTLogInfo(@"Could not register userId to chabok with channels");
-        }
+}
+
+RCT_EXPORT_METHOD(unregister) {
+    [PushClientManager.defaultManager unregisterUser];
+}
+
+RCT_EXPORT_METHOD(getInstallationId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    NSString *installationId = [PushClientManager.defaultManager getInstallationId];
+    if (!installationId) {
+        NSError *error = [NSError.alloc initWithDomain:@"Not registered"
+                                                  code:500
+                                              userInfo:@{
+                                                         @"message":@"The installationId is null, You didn't register yet!"
+                                                         }];
+        reject(@"500",@"The installationId is null, You didn't register yet!",error);
+    } else {
+        resolve(installationId);
     }
-    
-    RCT_EXPORT_METHOD(unregister) {
-        [PushClientManager.defaultManager unregisterUser];
+}
+
+RCT_EXPORT_METHOD(getUserId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    NSString *userId = [PushClientManager.defaultManager userId];
+    if (!userId) {
+        NSError *error = [NSError.alloc initWithDomain:@"Not registered"
+                                                  code:500
+                                              userInfo:@{
+                                                         @"message":@"The userId is null, You didn't register yet!"
+                                                         }];
+        reject(@"500",@"The userId is null, You didn't register yet!",error);
+    } else {
+        resolve(userId);
     }
-    
-    RCT_EXPORT_METHOD(getInstallationId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-        NSString *installationId = [PushClientManager.defaultManager getInstallationId];
-        if (!installationId) {
-            NSError *error = [NSError.alloc initWithDomain:@"Not registered"
-                                                      code:500
-                                                  userInfo:@{
-                                                             @"message":@"The installationId is null, You didn't register yet!"
-                                                             }];
-            reject(@"500",@"The installationId is null, You didn't register yet!",error);
-        } else {
-            resolve(installationId);
-        }
-    }
-    
-    RCT_EXPORT_METHOD(getUserId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-        NSString *userId = [PushClientManager.defaultManager userId];
-        if (!userId) {
-            NSError *error = [NSError.alloc initWithDomain:@"Not registered"
-                                                      code:500
-                                                  userInfo:@{
-                                                             @"message":@"The userId is null, You didn't register yet!"
-                                                             }];
-            reject(@"500",@"The userId is null, You didn't register yet!",error);
-        } else {
-            resolve(userId);
-        }
-    }
-    
+}
+
 #pragma mark - dev
-    
-    RCT_EXPORT_METHOD(setDevelopment:(BOOL) devMode) {
-        [PushClientManager setDevelopment:devMode];
-    }
-    
+
+RCT_EXPORT_METHOD(setDevelopment:(BOOL) devMode) {
+    [PushClientManager setDevelopment:devMode];
+}
+
 #pragma mark - tags
-    
-    RCT_EXPORT_METHOD(addTag:(NSString *) tagName resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        [PushClientManager.defaultManager addTag:tagName
+
+RCT_EXPORT_METHOD(addTag:(NSString *) tagName resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [PushClientManager.defaultManager addTag:tagName
+                                     success:^(NSInteger count) {
+                                         resolve(@{@"count":@(count)});
+                                     } failure:^(NSError *error) {
+                                         NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
+                                         reject(errorCode,error.domain,error);
+                                     }];
+}
+RCT_EXPORT_METHOD(addTags:(NSArray *) tagsName resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [PushClientManager.defaultManager addTags:tagsName
+                                      success:^(NSInteger count) {
+                                          resolve(@{@"count":@(count)});
+                                      } failure:^(NSError *error) {
+                                          NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
+                                          reject(errorCode,error.domain,error);
+                                      }];
+}
+RCT_EXPORT_METHOD(removeTag:(NSString *) tagName resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [PushClientManager.defaultManager removeTag:tagName
+                                        success:^(NSInteger count) {
+                                            resolve(@{@"count":@(count)});
+                                        } failure:^(NSError *error) {
+                                            NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
+                                            reject(errorCode,error.domain,error);
+                                        }];
+}
+RCT_EXPORT_METHOD(removeTags:(NSArray *) tagsName resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [PushClientManager.defaultManager removeTags:tagsName
                                          success:^(NSInteger count) {
                                              resolve(@{@"count":@(count)});
                                          } failure:^(NSError *error) {
                                              NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
                                              reject(errorCode,error.domain,error);
                                          }];
-    }
-    RCT_EXPORT_METHOD(addTags:(NSArray *) tagsName resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        [PushClientManager.defaultManager addTags:tagsName
-                                          success:^(NSInteger count) {
-                                              resolve(@{@"count":@(count)});
-                                          } failure:^(NSError *error) {
-                                              NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
-                                              reject(errorCode,error.domain,error);
-                                          }];
-    }
-    RCT_EXPORT_METHOD(removeTag:(NSString *) tagName resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        [PushClientManager.defaultManager removeTag:tagName
-                                            success:^(NSInteger count) {
-                                                resolve(@{@"count":@(count)});
-                                            } failure:^(NSError *error) {
-                                                NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
-                                                reject(errorCode,error.domain,error);
-                                            }];
-    }
-    RCT_EXPORT_METHOD(removeTags:(NSArray *) tagsName resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        [PushClientManager.defaultManager removeTags:tagsName
-                                             success:^(NSInteger count) {
-                                                 resolve(@{@"count":@(count)});
-                                             } failure:^(NSError *error) {
-                                                 NSString *errorCode = [NSString stringWithFormat:@"%zd",error.code];
-                                                 reject(errorCode,error.domain,error);
-                                             }];
-    }
-    
+}
+
 #pragma mark - publish
+
+//RCT_EXPORT_METHOD(publish:(NSString *) channel text:(NSString *) text resolver:(RCTPromiseResolveBlock)resolve
+//                  rejecter:(RCTPromiseRejectBlock)reject) {
+//  BOOL publishState = [PushClientManager.defaultManager publish:channel withText:text];
+//  resolve(@[@{@"published":@(publishState)}]);
+//}
+//
+//RCT_EXPORT_METHOD(publish:(NSString *) userId channel:(NSString *) channel text:(NSString *) text resolver:(RCTPromiseResolveBlock)resolve
+//                  rejecter:(RCTPromiseRejectBlock)reject) {
+//  BOOL publishState = [PushClientManager.defaultManager publish:userId toChannel:channel withText:text];
+//  resolve(@[@{@"published":@(publishState)}]);
+//}
+
+RCT_EXPORT_METHOD(publish:(NSDictionary *) message resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSDictionary *data = [message valueForKey:@"data"];
+    NSString *userId = [message valueForKey:@"userId"];
+    NSString *content = [message valueForKey:@"content"];
+    NSString *channel = [message valueForKey:@"channel"];
     
-    //RCT_EXPORT_METHOD(publish:(NSString *) channel text:(NSString *) text resolver:(RCTPromiseResolveBlock)resolve
-    //                  rejecter:(RCTPromiseRejectBlock)reject) {
-    //  BOOL publishState = [PushClientManager.defaultManager publish:channel withText:text];
-    //  resolve(@[@{@"published":@(publishState)}]);
-    //}
-    //
-    //RCT_EXPORT_METHOD(publish:(NSString *) userId channel:(NSString *) channel text:(NSString *) text resolver:(RCTPromiseResolveBlock)resolve
-    //                  rejecter:(RCTPromiseRejectBlock)reject) {
-    //  BOOL publishState = [PushClientManager.defaultManager publish:userId toChannel:channel withText:text];
-    //  resolve(@[@{@"published":@(publishState)}]);
-    //}
-    
-    RCT_EXPORT_METHOD(publish:(NSDictionary *) message resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        NSDictionary *data = [message valueForKey:@"data"];
-        NSString *userId = [message valueForKey:@"userId"];
-        NSString *content = [message valueForKey:@"content"];
-        NSString *channel = [message valueForKey:@"channel"];
-        
-        PushClientMessage *chabokMessage;
-        if (data) {
-            chabokMessage = [[PushClientMessage alloc] initWithMessage:content withData:data toUserId:userId channel:channel];
-        } else {
-            chabokMessage = [[PushClientMessage alloc] initWithMessage:content toUserId:userId channel:channel];
-        }
-        
-        BOOL publishState = [PushClientManager.defaultManager publish:chabokMessage];
-        resolve(@{@"published":@(publishState)});
+    PushClientMessage *chabokMessage;
+    if (data) {
+        chabokMessage = [[PushClientMessage alloc] initWithMessage:content withData:data toUserId:userId channel:channel];
+    } else {
+        chabokMessage = [[PushClientMessage alloc] initWithMessage:content toUserId:userId channel:channel];
     }
     
+    BOOL publishState = [PushClientManager.defaultManager publish:chabokMessage];
+    resolve(@{@"published":@(publishState)});
+}
+
 #pragma mark - publish event
-    
-    RCT_EXPORT_METHOD(publishEvent:(NSString *) eventName data:(NSDictionary *) data resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        [PushClientManager.defaultManager publishEvent:eventName data:data];
-    }
-    
+
+RCT_EXPORT_METHOD(publishEvent:(NSString *) eventName data:(NSDictionary *) data resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [PushClientManager.defaultManager publishEvent:eventName data:data];
+}
+
 #pragma mark - subscribe
-    RCT_EXPORT_METHOD(subscribe:(NSString *) channel) {
-        [PushClientManager.defaultManager subscribe:channel];
-    }
-    
-    RCT_EXPORT_METHOD(subscribeEvent:(NSString *) eventName) {
+RCT_EXPORT_METHOD(subscribe:(NSString *) channel) {
+    [PushClientManager.defaultManager subscribe:channel];
+}
+
+RCT_EXPORT_METHOD(subscribeEvent:(NSString *) eventName) {
+    [PushClientManager.defaultManager subscribeEvent:eventName];
+}
+
+RCT_EXPORT_METHOD(subscribeEvent:(NSString *) eventName installationId:(NSString *) installationId) {
+    if (!installationId){
         [PushClientManager.defaultManager subscribeEvent:eventName];
+    } else {
+        [PushClientManager.defaultManager subscribeEvent:eventName installationId:installationId];
     }
-    
-    RCT_EXPORT_METHOD(subscribeEvent:(NSString *) eventName installationId:(NSString *) installationId) {
-        if (!installationId){
-            [PushClientManager.defaultManager subscribeEvent:eventName];
-        } else {
-            [PushClientManager.defaultManager subscribeEvent:eventName installationId:installationId];
-        }
-    }
-    
+}
+
 #pragma mark - unsubscribe
-    RCT_EXPORT_METHOD(unSubscribe:(NSString *) channel) {
-        [PushClientManager.defaultManager unsubscribe:channel];
-    }
-    
-    RCT_EXPORT_METHOD(unSubscribeEvent:(NSString *) eventName) {
+RCT_EXPORT_METHOD(unSubscribe:(NSString *) channel) {
+    [PushClientManager.defaultManager unsubscribe:channel];
+}
+
+RCT_EXPORT_METHOD(unSubscribeEvent:(NSString *) eventName) {
+    [PushClientManager.defaultManager unsubscribeEvent:eventName];
+}
+
+RCT_EXPORT_METHOD(unSubscribeEvent:(NSString *) eventName installationId:(NSString *) installationId) {
+    if (!installationId){
         [PushClientManager.defaultManager unsubscribeEvent:eventName];
+    } else {
+        [PushClientManager.defaultManager unsubscribeEvent:eventName installationId:installationId];
     }
-    
-    RCT_EXPORT_METHOD(unSubscribeEvent:(NSString *) eventName installationId:(NSString *) installationId) {
-        if (!installationId){
-            [PushClientManager.defaultManager unsubscribeEvent:eventName];
-        } else {
-            [PushClientManager.defaultManager unsubscribeEvent:eventName installationId:installationId];
-        }
-    }
-    
+}
+
 #pragma mark - badge
-    RCT_EXPORT_METHOD(resetBadge) {
-        [PushClientManager resetBadge];
-    }
-    
+RCT_EXPORT_METHOD(resetBadge) {
+    [PushClientManager resetBadge];
+}
+
 #pragma mark - track
-    RCT_EXPORT_METHOD(track:(NSString *) trackName data:(NSDictionary *) data) {
-        [PushClientManager.defaultManager track:trackName data:data];
-    }
-    
+RCT_EXPORT_METHOD(track:(NSString *) trackName data:(NSDictionary *) data) {
+    [PushClientManager.defaultManager track:trackName data:data];
+}
+
 RCT_EXPORT_METHOD(trackPurchase:(NSString *) eventName data:(NSDictionary *) data) {
     ChabokEvent *chabokEvent = [[ChabokEvent alloc] init];
     double revenue = 0;
@@ -352,9 +352,9 @@ RCT_EXPORT_METHOD(trackPurchase:(NSString *) eventName data:(NSDictionary *) dat
 }
 
 #pragma mark - default tracker
-    RCT_EXPORT_METHOD(setDefaultTracker:(NSString *) defaultTracker) {
-        [PushClientManager.defaultManager setDefaultTracker:defaultTracker];;
-    }
+RCT_EXPORT_METHOD(setDefaultTracker:(NSString *) defaultTracker) {
+    [PushClientManager.defaultManager setDefaultTracker:defaultTracker];;
+}
 
 #pragma mark - user attributes
 RCT_EXPORT_METHOD(setUserAttributes:(NSDictionary *) attributes) {
@@ -374,11 +374,11 @@ RCT_EXPORT_METHOD(setDefaultNotificationChannel) {
 }
 
 #pragma mark - deeplink
-    RCT_EXPORT_METHOD(appWillOpenUrl:(NSString *) link) {
-        if(!link){
-            return;
-        }
-        NSURL *url = [[NSURL alloc] initWithString:link];
+RCT_EXPORT_METHOD(appWillOpenUrl:(NSString *) link) {
+    if(!link){
+        return;
+    }
+    NSURL *url = [[NSURL alloc] initWithString:link];
     [PushClientManager.defaultManager appWillOpenUrl:url];
 }
 
@@ -391,16 +391,16 @@ RCT_EXPORT_METHOD(setOnDeeplinkResponseListener:(BOOL) shouldLaunchDeeplink reso
 RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
     if (self.bridge) {
         if (_coldStartNotificationResult) {
-                [self sendEventWithName:@"notificationOpened" body:_coldStartNotificationResult];
-            }
+            [self sendEventWithName:@"notificationOpened" body:_coldStartNotificationResult];
         }
+    }
 }
 
 #pragma mark - chabok delegate methods
 - (BOOL)chabokDeeplinkResponse:(NSURL *)deeplink {
     if(deeplink && self.getDeepLinkResponseCallback){
-        self.getDeepLinkResponseCallback(deeplink);
-    } else{
+        self.getDeepLinkResponseCallback(deeplink.absoluteString);
+    } else {
         return NO;
     }
     return self.shouldLaunchDeeplink;
@@ -409,7 +409,7 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
 - (NSArray<NSString *> *)supportedEvents{
     return @[@"connectionStatus",@"onEvent",@"onMessage", @"ChabokMessageReceived", @"onSubscribe", @"onUnsubscribe", @"onRegister", @"notificationOpened"];
 }
-    
+
 -(void) pushClientManagerDidReceivedMessage:(PushClientMessage *)message{
     if (self.bridge) {
         NSMutableDictionary *messageDict = [NSMutableDictionary.alloc initWithDictionary:[message toDict]];
@@ -419,7 +419,7 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
         [self sendEventWithName:@"ChabokMessageReceived" body:messageDict];
     }
 }
-    
+
 -(void) pushClientManagerDidReceivedEventMessage:(EventMessage *)eventMessage{
     if (self.bridge) {
         NSDictionary *eventMessageDic =  @{
@@ -435,7 +435,7 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
         [self sendEventWithName:@"onEvent" body:[eventPayload copy]];
     }
 }
-    
+
 -(void) pushClientManagerDidChangedServerConnectionState {
     NSString *connectionState = @"";
     if (PushClientManager.defaultManager.connectionState == PushClientServerConnectedState) {
@@ -454,21 +454,21 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
     
     [self sendEventWithName:@"connectionStatus" body:connectionState];
 }
-    
+
 -(void) pushClientManagerDidSubscribed:(NSString *)channel{
     [self sendEventWithName:@"onSubscribe" body:@{@"name":channel}];
 }
 -(void) pushClientManagerDidFailInSubscribe:(NSError *)error{
     [self sendEventWithName:@"onSubscribe" body:@{@"error":error}];
 }
-    
+
 -(void) pushClientManagerDidUnsubscribed:(NSString *)channel{
     [self sendEventWithName:@"onUnsubscribe" body:@{@"name":channel}];
 }
 -(void) pushClientManagerDidFailInUnsubscribe:(NSError *)error{
     [self sendEventWithName:@"onUnsubscribe" body:@{@"error":error}];
 }
-    
+
 +(NSDictionary *) notificationOpened:(NSDictionary *) payload actionId:(NSString *) actionId{
     NSString *actionType;
     NSString *actionUrl;
@@ -508,15 +508,15 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
     
     return notificationData;
 }
-    
+
 +(NSDictionary *) notificationOpened:(NSDictionary *) payload{
     return [AdpPushClient notificationOpened:payload actionId:UNNotificationDefaultActionIdentifier];
 }
-    
+
 - (void)invalidate {
     self.appId = nil;
 }
-    
+
 -(void) userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler{
     NSDictionary *notificationData = [AdpPushClient notificationOpened:response.notification.request.content.userInfo actionId:response.actionIdentifier];
     
@@ -528,7 +528,7 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
         _coldStartNotificationResult = notificationData;
     }
 }
-    
+
 +(NSString *)getActionUrlFrom:(NSString *)actionId actions:(NSArray *)actions {
     NSString *actionUrl;
     for (NSDictionary *action in actions) {
@@ -539,5 +539,5 @@ RCT_EXPORT_METHOD(setNotificationOpenedHandler) {
     }
     return actionUrl;
 }
-    
-    @end
+
+@end

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -366,6 +366,10 @@ RCT_EXPORT_METHOD(getUserAttributes:(RCTPromiseResolveBlock)resolve
     resolve(PushClientManager.defaultManager.userAttributes);
 }
 
+RCT_EXPORT_METHOD(incrementUserAttribute:(NSString *) attribute value:(NSInteger) value) {
+    [PushClientManager.defaultManager incrementUserAttribute:attribute value:value];
+}
+
     }
     
 #pragma mark - deeplink

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -353,16 +353,17 @@ RCT_EXPORT_METHOD(trackPurchase:(NSString *) eventName data:(NSDictionary *) dat
     RCT_EXPORT_METHOD(setDefaultTracker:(NSString *) defaultTracker) {
         [PushClientManager.defaultManager setDefaultTracker:defaultTracker];;
     }
-    
-#pragma mark - userInfo
-    RCT_EXPORT_METHOD(setUserInfo:(NSDictionary *) userInfo) {
-        [PushClientManager.defaultManager setUserInfo:userInfo];;
-    }
-    
-    RCT_EXPORT_METHOD(getUserInfo:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        NSDictionary *userInfo = PushClientManager.defaultManager.userInfo;
-        resolve(userInfo);
+
+#pragma mark - user attributes
+RCT_EXPORT_METHOD(setUserAttributes:(NSDictionary *) attributes) {
+    [PushClientManager.defaultManager setUserAttributes:attributes];
+}
+
+RCT_EXPORT_METHOD(getUserAttributes:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(PushClientManager.defaultManager.userAttributes);
+}
+
     }
     
 #pragma mark - deeplink

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -370,8 +370,9 @@ RCT_EXPORT_METHOD(incrementUserAttribute:(NSString *) attribute value:(NSInteger
     [PushClientManager.defaultManager incrementUserAttribute:attribute value:value];
 }
 
-    }
-    
+RCT_EXPORT_METHOD(setDefaultNotificationChannel) {
+}
+
 #pragma mark - deeplink
     RCT_EXPORT_METHOD(appWillOpenUrl:(NSString *) link) {
         if(!link){

--- a/ios/AdpPushClient.m
+++ b/ios/AdpPushClient.m
@@ -330,6 +330,25 @@
         [PushClientManager.defaultManager track:trackName data:data];
     }
     
+RCT_EXPORT_METHOD(trackPurchase:(NSString *) eventName data:(NSDictionary *) data) {
+    ChabokEvent *chabokEvent = [[ChabokEvent alloc] init];
+    double revenue = 0;
+    NSString *currency = nil;
+    if (![data valueForKey:@"revenue"]) {
+        [NSException raise:@"Invalid revenue" format:@"Please provide a revenue."];
+    }
+    chabokEvent.revenue = [[data valueForKey:@"revenue"] doubleValue];
+    if ([data valueForKey:@"currency"]) {
+        chabokEvent.currency = [data valueForKey:@"currency"];
+    }
+    if ([data valueForKey:@"data"]) {
+        chabokEvent.data = [data valueForKey:@"data"];
+    }
+    
+    [PushClientManager.defaultManager trackPurchase:eventName
+                                        chabokEvent:chabokEvent];
+}
+
 #pragma mark - default tracker
     RCT_EXPORT_METHOD(setDefaultTracker:(NSString *) defaultTracker) {
         [PushClientManager.defaultManager setDefaultTracker:defaultTracker];;

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -62,6 +62,14 @@ export class AdpPushClient {
 
     setUserAttributes = (userAttributes) => AdpNativeModule.setUserAttributes(userAttributes);
     getUserAttributes = () => AdpNativeModule.getUserAttributes();
+    setDeeplinkCallbackListener = (shouldLaunchDeeplink, deeplinkCallbackListener) => {
+        if (deeplinkCallbackListener){
+            AdpNativeModule.setDeeplinkCallbackListener(shouldLaunchDeeplink).then((deeplink) => {
+                deeplinkCallbackListener(deeplink)
+            });
+        }
+    }
+
     trackPurchase = (eventName, chabokEvent) => {
         if (eventName){
             AdpNativeModule.trackPurchase(eventName, chabokEvent);

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -60,6 +60,8 @@ export class AdpPushClient {
     getUserInfo = () => AdpNativeModule.getUserAttributes();
 
 
+    setUserAttributes = (userAttributes) => AdpNativeModule.setUserAttributes(userAttributes);
+    getUserAttributes = () => AdpNativeModule.getUserAttributes();
     trackPurchase = (eventName, chabokEvent) => {
         if (eventName){
             AdpNativeModule.trackPurchase(eventName, chabokEvent);

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -64,9 +64,7 @@ export class AdpPushClient {
     getUserAttributes = () => AdpNativeModule.getUserAttributes();
 
     incrementUserAttribute = (attribute, value) => {
-        if (!value) {
-            value = 1;
-        }
+        value = value || 1;
         AdpNativeModule.incrementUserAttribute(attribute, value);
     }
 
@@ -79,15 +77,11 @@ export class AdpPushClient {
     }
 
     trackPurchase = (eventName, chabokEvent) => {
-        if (eventName){
-            AdpNativeModule.trackPurchase(eventName, chabokEvent);
-        }
+        AdpNativeModule.trackPurchase(eventName, chabokEvent);
     }
 
     setDefaultNotificationChannel = (channelName) => {
-        if (channelName){
-            setDefaultNotificationChannel(channelName);
-        }
+        setDefaultNotificationChannel(channelName);
     }
 
     unregister = () => AdpNativeModule.unregister();

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -84,7 +84,11 @@ export class AdpPushClient {
         }
     }
 
-    getUserInfo = () => AdpNativeModule.getUserInfo();
+    setDefaultNotificationChannel = (channelName) => {
+        if (channelName){
+            setDefaultNotificationChannel(channelName);
+        }
+    }
 
     unregister = () => AdpNativeModule.unregister();
 

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -50,6 +50,11 @@ export class AdpPushClient {
     setDefaultTracker = (defaultTracker) => AdpNativeModule.setDefaultTracker(defaultTracker);
 
     setUserInfo = (userInfo) => AdpNativeModule.setUserInfo(userInfo);
+    trackPurchase = (eventName, chabokEvent) => {
+        if (eventName){
+            AdpNativeModule.trackPurchase(eventName, chabokEvent);
+        }
+    }
 
     getUserInfo = () => AdpNativeModule.getUserInfo();
 

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -62,6 +62,14 @@ export class AdpPushClient {
 
     setUserAttributes = (userAttributes) => AdpNativeModule.setUserAttributes(userAttributes);
     getUserAttributes = () => AdpNativeModule.getUserAttributes();
+
+    incrementUserAttribute = (attribute, value) => {
+        if (!value) {
+            value = 1;
+        }
+        AdpNativeModule.incrementUserAttribute(attribute, value);
+    }
+
     setDeeplinkCallbackListener = (shouldLaunchDeeplink, deeplinkCallbackListener) => {
         if (deeplinkCallbackListener){
             AdpNativeModule.setDeeplinkCallbackListener(shouldLaunchDeeplink).then((deeplink) => {

--- a/lib/modules/core/chabok.js
+++ b/lib/modules/core/chabok.js
@@ -49,7 +49,17 @@ export class AdpPushClient {
 
     setDefaultTracker = (defaultTracker) => AdpNativeModule.setDefaultTracker(defaultTracker);
 
-    setUserInfo = (userInfo) => AdpNativeModule.setUserInfo(userInfo);
+    /**
+     * @deprecated the function has been replaced with AdpNativeModule.setUserAttributes()
+     */
+    setUserInfo = (userInfo) => AdpNativeModule.setUserAttributes(userInfo);
+
+    /**
+     * @deprecated the function has been replaced with AdpNativeModule.getUserAttributes()
+     */
+    getUserInfo = () => AdpNativeModule.getUserAttributes();
+
+
     trackPurchase = (eventName, chabokEvent) => {
         if (eventName){
             AdpNativeModule.trackPurchase(eventName, chabokEvent);


### PR DESCRIPTION
- Update Chabok iOS SDK ([v1.20.0](https://github.com/chabokpush/chabok-client-ios/releases/tag/v1.20.0))
- Update Chabok android SDK ([v2.17.0](https://github.com/chabokpush/chabok-client-android/releases/tag/v2.17.0))
- Now Chabok supports user revenue with `trackPurchase` method.
- Now Chabok supports direct/in-direct notification influence.
- Now Chabok supports deferred deep linking with `setDeeplinkCallbackListener` method.
- Add `getUserAttributes` and `setUserAttributes` method.
- Add `setDefaultNotificationChannel` method for changing the default name of notification channel (Android 8 or higher).

### Upgrade:
- `getUserInfo` and `setUserInfo` is deprecated and replaced with `getUserAttributes` and `setUserAttributes`.
